### PR TITLE
order calphas by residue for conveniences

### DIFF
--- a/src/protgeom/bio.py
+++ b/src/protgeom/bio.py
@@ -9,7 +9,7 @@ class Protein:
     """
     num_atoms: int
     cords: ndarray
-    caphas: list
+    calphas: list
     name: string = 'unknown'
 
     def __str__(self):
@@ -17,4 +17,4 @@ class Protein:
     
     @property
     def calpha_cords(self) -> ndarray:
-        return self.cords[[calpha[0] for calpha in self.caphas],:]
+        return self.cords[[calpha[0] for calpha in self.calphas],:]

--- a/src/protgeom/pdb.py
+++ b/src/protgeom/pdb.py
@@ -46,4 +46,5 @@ def parsePDBFile(pdb_f, name='unknown'):
 
     cords_folded = cords.reshape(-1,3)
     atom_num = cords_folded.shape[0]
-    return Protein(atom_num, cords_folded, calphas, name)
+    sorted_caphas = sorted(calphas,key=lambda x: x[1])
+    return Protein(atom_num, cords_folded, sorted_caphas, name)

--- a/tests/protgeom/test_pdb.py
+++ b/tests/protgeom/test_pdb.py
@@ -8,7 +8,7 @@ from src.protgeom.pdb import fetchPDB
 def example_pdb_file():
     return io.StringIO("""
 ATOM      1  N   ILE A  16      -8.155   9.648  20.365  1.00 10.68           N
-ATOM      2  CA  ILE A  16      -8.150   8.766  19.179  1.00 10.68           C
+ATOM      2  CA  ILE A  17      -8.150   8.766  19.179  1.00 10.68           C
 ATOM      3  C   ILE A  16      -9.405   9.018  18.348  1.00 10.68           C
 ATOM      4  O   ILE A  16     -10.533   8.888  18.870  1.00 10.68           O
 ATOM      5  CB  ILE A  16      -8.091   7.261  19.602  1.00 10.68           C
@@ -16,7 +16,7 @@ ATOM      6  CG1 ILE A  16      -6.898   6.882  20.508  1.00  7.42           C
 ATOM      7  CG2 ILE A  16      -8.178   6.281  18.408  1.00  7.42           C
 ATOM      8  CD1 ILE A  16      -5.555   6.893  19.773  1.00  7.42           C
 ATOM      9  N   VAL A  17      -9.224   9.305  17.090  1.00  9.63           N
-ATOM     10  CA  VAL A  17     -10.351   9.448  16.157  1.00  9.63           C
+ATOM     10  CA  VAL A  16     -10.351   9.448  16.157  1.00  9.63           C
 ATOM     11  C   VAL A  17     -10.500   8.184  15.315  1.00  9.63           C
 ATOM     12  O   VAL A  17      -9.496   7.688  14.748  1.00  9.63           O
 ATOM     13  CB  VAL A  17     -10.123  10.665  15.222  1.00  9.63           C
@@ -33,11 +33,14 @@ def test_parsePDBFile():
     assert prot.cords[5,2] == 20.508 # atom 6 possition z
 
 
-def test_parsePDBFileCAlphas():
+def test_parsePDBFile_CAlphas():
     prot = parsePDBFile(example_pdb_file()) 
-    assert prot.caphas == [(1, 15), (9, 16), (16, 17)] 
-    assert prot.calpha_cords[1,0] == -10.351 # second carbon alpha X cordinate
+    assert prot.calphas == [(9, 15), (1, 16), (16, 17)] 
+    assert prot.calpha_cords[1,0] == -8.15 # second carbon alpha X cordinate
 
+def test_parsePDB_calphas_order_by_residue():
+     prot = parsePDBFile(example_pdb_file())
+     assert all([prot.calphas[i][1] < prot.calphas[i + 1][1] for i in range(len(prot.calphas) - 1)])
 
 def test_fetchPDB():
     prot = fetchPDB('2ptn')


### PR DESCRIPTION
Order calphas by residue rather that atom number.